### PR TITLE
Phase 2.3: Redisキャッシュ層実装（TDD） (vibe-kanban)

### DIFF
--- a/api/app/controllers/api/posts_controller.rb
+++ b/api/app/controllers/api/posts_controller.rb
@@ -1,0 +1,48 @@
+module Api
+  class PostsController < ApplicationController
+    DEFAULT_LIMIT = 50
+
+    # POST /api/posts
+    def create
+      post = Post.new(post_params)
+
+      if post.save
+        # Cache the new post
+        cache_service.cache_post(post)
+
+        render json: post, status: :created
+      else
+        render json: { error: post.errors.full_messages.join(', ') }, status: :unprocessable_entity
+      end
+    end
+
+    # GET /api/posts
+    def index
+      limit = params.fetch(:limit, DEFAULT_LIMIT).to_i
+
+      # Try to get cached post IDs
+      cached_ids = cache_service.get_cached_ids(limit)
+
+      if cached_ids.any?
+        # Fetch posts from DB using cached IDs, preserving order
+        posts = Post.where(id: cached_ids).index_by(&:id)
+        ordered_posts = cached_ids.map { |id| posts[id] }.compact
+      else
+        # Cache miss: fetch from DB
+        ordered_posts = Post.limit(limit).to_a
+      end
+
+      render json: ordered_posts
+    end
+
+    private
+
+    def post_params
+      params.require(:post).permit(:body)
+    end
+
+    def cache_service
+      @cache_service ||= PostCacheService.new
+    end
+  end
+end

--- a/api/app/services/post_cache_service.rb
+++ b/api/app/services/post_cache_service.rb
@@ -1,0 +1,35 @@
+class PostCacheService
+  CACHE_KEY = 'tl:global'
+  MAX_CACHED_POSTS = 50
+  DEFAULT_LIMIT = 50
+
+  def initialize
+    @redis = Redis.new(url: ENV.fetch('REDIS_URL', 'redis://redis:6379/1'))
+  end
+
+  # Add a post to the cache
+  # @param post [Post] The post to cache
+  # @return [void]
+  def cache_post(post)
+    redis.lpush(CACHE_KEY, post.id)
+    redis.ltrim(CACHE_KEY, 0, MAX_CACHED_POSTS - 1)
+  rescue Redis::BaseError => e
+    Rails.logger.error("Redis error in cache_post: #{e.message}")
+    # Silently fail - caching is not critical
+  end
+
+  # Get cached post IDs
+  # @param limit [Integer] Number of post IDs to retrieve
+  # @return [Array<Integer>] Array of post IDs
+  def get_cached_ids(limit = DEFAULT_LIMIT)
+    cached_ids = redis.lrange(CACHE_KEY, 0, limit - 1)
+    cached_ids.map(&:to_i)
+  rescue Redis::BaseError => e
+    Rails.logger.error("Redis error in get_cached_ids: #{e.message}")
+    []
+  end
+
+  private
+
+  attr_reader :redis
+end

--- a/api/config/initializers/redis.rb
+++ b/api/config/initializers/redis.rb
@@ -1,0 +1,2 @@
+# Redis configuration for caching
+Redis.new(url: ENV.fetch('REDIS_URL', 'redis://redis:6379/1'))

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -5,6 +5,11 @@ Rails.application.routes.draw do
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
 
+  # API routes
+  namespace :api do
+    resources :posts, only: [:index, :create]
+  end
+
   # Defines the root path route ("/")
   # root "posts#index"
 end

--- a/api/spec/requests/api/posts_spec.rb
+++ b/api/spec/requests/api/posts_spec.rb
@@ -1,0 +1,195 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::Posts', type: :request do
+  let(:redis) { Redis.new }
+
+  before do
+    # Clean up Redis before each test
+    redis.del('tl:global')
+  end
+
+  after do
+    # Clean up Redis after each test
+    redis.del('tl:global')
+  end
+
+  describe 'POST /api/posts' do
+    context 'with valid parameters' do
+      let(:valid_params) { { post: { body: 'Hello, World!' } } }
+
+      it 'creates a new post' do
+        expect {
+          post '/api/posts', params: valid_params
+        }.to change(Post, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+      end
+
+      it 'returns the created post' do
+        post '/api/posts', params: valid_params
+
+        json = JSON.parse(response.body)
+        expect(json['body']).to eq('Hello, World!')
+        expect(json['author_name']).to eq('guest')
+        expect(json['id']).to be_present
+        expect(json['created_at']).to be_present
+      end
+
+      it 'caches the post ID in Redis' do
+        post '/api/posts', params: valid_params
+
+        json = JSON.parse(response.body)
+        post_id = json['id']
+
+        cached_ids = redis.lrange('tl:global', 0, -1)
+        expect(cached_ids).to include(post_id.to_s)
+      end
+
+      it 'adds the post to the beginning of the cache' do
+        old_post = create(:post, body: 'Old post')
+        redis.lpush('tl:global', old_post.id)
+
+        post '/api/posts', params: valid_params
+
+        json = JSON.parse(response.body)
+        new_post_id = json['id']
+
+        cached_ids = redis.lrange('tl:global', 0, -1)
+        expect(cached_ids.first).to eq(new_post_id.to_s)
+      end
+    end
+
+    context 'with invalid parameters' do
+      it 'returns an error when body is blank' do
+        post '/api/posts', params: { post: { body: '' } }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        json = JSON.parse(response.body)
+        expect(json['error']).to include("can't be blank")
+      end
+
+      it 'returns an error when body exceeds 140 characters' do
+        post '/api/posts', params: { post: { body: 'a' * 141 } }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        json = JSON.parse(response.body)
+        expect(json['error']).to include('too long')
+      end
+
+      it 'does not cache invalid posts' do
+        post '/api/posts', params: { post: { body: '' } }
+
+        cached_ids = redis.lrange('tl:global', 0, -1)
+        expect(cached_ids).to be_empty
+      end
+    end
+  end
+
+  describe 'GET /api/posts' do
+    context 'when cache is empty' do
+      it 'returns posts from database' do
+        posts = create_list(:post, 3)
+
+        get '/api/posts'
+
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        expect(json.length).to eq(3)
+      end
+
+      it 'returns posts in descending order by created_at' do
+        old_post = create(:post, body: 'Old post', created_at: 2.days.ago)
+        new_post = create(:post, body: 'New post', created_at: 1.day.ago)
+
+        get '/api/posts'
+
+        json = JSON.parse(response.body)
+        expect(json.first['id']).to eq(new_post.id)
+        expect(json.second['id']).to eq(old_post.id)
+      end
+    end
+
+    context 'when cache has post IDs' do
+      it 'returns posts from cache' do
+        posts = create_list(:post, 5)
+        # Cache the IDs manually
+        posts.reverse_each { |p| redis.lpush('tl:global', p.id) }
+
+        get '/api/posts'
+
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        expect(json.length).to eq(5)
+      end
+
+      it 'maintains the cache order' do
+        old_post = create(:post, body: 'Old post')
+        new_post = create(:post, body: 'New post')
+
+        redis.lpush('tl:global', old_post.id)
+        redis.lpush('tl:global', new_post.id)
+
+        get '/api/posts'
+
+        json = JSON.parse(response.body)
+        expect(json.first['id']).to eq(new_post.id)
+        expect(json.second['id']).to eq(old_post.id)
+      end
+
+      it 'handles deleted posts in cache gracefully' do
+        post1 = create(:post, body: 'Post 1')
+        post2 = create(:post, body: 'Post 2')
+        post3 = create(:post, body: 'Post 3')
+
+        redis.lpush('tl:global', post1.id)
+        redis.lpush('tl:global', post2.id)
+        redis.lpush('tl:global', post3.id)
+
+        # Delete post2 from database but leave it in cache
+        post2.destroy
+
+        get '/api/posts'
+
+        json = JSON.parse(response.body)
+        expect(json.length).to eq(2)
+        expect(json.map { |p| p['id'] }).to contain_exactly(post1.id, post3.id)
+      end
+    end
+
+    context 'with limit parameter' do
+      it 'respects the limit parameter' do
+        create_list(:post, 10)
+
+        get '/api/posts', params: { limit: 5 }
+
+        json = JSON.parse(response.body)
+        expect(json.length).to eq(5)
+      end
+
+      it 'defaults to 50 posts when no limit is provided' do
+        create_list(:post, 60)
+
+        get '/api/posts'
+
+        json = JSON.parse(response.body)
+        expect(json.length).to eq(50)
+      end
+    end
+
+    context 'when Redis is unavailable' do
+      before do
+        allow_any_instance_of(PostCacheService).to receive(:get_cached_ids).and_return([])
+      end
+
+      it 'falls back to database query' do
+        posts = create_list(:post, 3)
+
+        get '/api/posts'
+
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        expect(json.length).to eq(3)
+      end
+    end
+  end
+end

--- a/api/spec/services/post_cache_service_spec.rb
+++ b/api/spec/services/post_cache_service_spec.rb
@@ -1,0 +1,111 @@
+require 'rails_helper'
+
+RSpec.describe PostCacheService, type: :service do
+  let(:redis) { Redis.new }
+  let(:service) { described_class.new }
+
+  before do
+    # Clean up Redis before each test
+    redis.del('tl:global')
+  end
+
+  after do
+    # Clean up Redis after each test
+    redis.del('tl:global')
+  end
+
+  describe '#cache_post' do
+    it 'adds post ID to the beginning of the global timeline cache' do
+      post = create(:post)
+
+      service.cache_post(post)
+
+      cached_ids = redis.lrange('tl:global', 0, -1)
+      expect(cached_ids).to eq([post.id.to_s])
+    end
+
+    it 'maintains the most recent 50 posts' do
+      # Create 51 posts
+      posts = (1..51).map { create(:post) }
+
+      # Cache all posts
+      posts.each { |post| service.cache_post(post) }
+
+      # Only 50 should remain
+      cached_ids = redis.lrange('tl:global', 0, -1)
+      expect(cached_ids.length).to eq(50)
+
+      # The newest 50 posts should be cached (excluding the oldest)
+      expected_ids = posts.reverse[0..49].map { |p| p.id.to_s }
+      expect(cached_ids).to eq(expected_ids)
+    end
+
+    it 'adds new posts to the beginning of the list' do
+      old_post = create(:post, body: 'Old post')
+      new_post = create(:post, body: 'New post')
+
+      service.cache_post(old_post)
+      service.cache_post(new_post)
+
+      cached_ids = redis.lrange('tl:global', 0, -1)
+      expect(cached_ids.first).to eq(new_post.id.to_s)
+      expect(cached_ids.second).to eq(old_post.id.to_s)
+    end
+  end
+
+  describe '#get_cached_ids' do
+    it 'retrieves the specified number of post IDs from cache' do
+      posts = (1..10).map { create(:post) }.reverse
+      posts.each { |post| service.cache_post(post) }
+
+      cached_ids = service.get_cached_ids(5)
+
+      expect(cached_ids.length).to eq(5)
+      expect(cached_ids).to eq(posts[0..4].map(&:id))
+    end
+
+    it 'returns an empty array when cache is empty' do
+      cached_ids = service.get_cached_ids(10)
+
+      expect(cached_ids).to eq([])
+    end
+
+    it 'returns all available IDs when fewer than limit exist' do
+      posts = (1..3).map { create(:post) }.reverse
+      posts.each { |post| service.cache_post(post) }
+
+      cached_ids = service.get_cached_ids(10)
+
+      expect(cached_ids.length).to eq(3)
+      expect(cached_ids).to eq(posts.map(&:id))
+    end
+
+    it 'defaults to 50 when no limit is specified' do
+      posts = (1..60).map { create(:post) }.reverse
+      posts.each { |post| service.cache_post(post) }
+
+      cached_ids = service.get_cached_ids
+
+      expect(cached_ids.length).to eq(50)
+    end
+  end
+
+  describe 'Redis connection error handling' do
+    it 'handles Redis connection errors gracefully in cache_post' do
+      post = create(:post)
+      allow(redis).to receive(:lpush).and_raise(Redis::CannotConnectError)
+      allow(service).to receive(:redis).and_return(redis)
+
+      expect { service.cache_post(post) }.not_to raise_error
+    end
+
+    it 'returns empty array on Redis connection errors in get_cached_ids' do
+      allow(redis).to receive(:lrange).and_raise(Redis::CannotConnectError)
+      allow(service).to receive(:redis).and_return(redis)
+
+      result = service.get_cached_ids(10)
+
+      expect(result).to eq([])
+    end
+  end
+end


### PR DESCRIPTION
## 概要
TDDでRedisキャッシュ層を実装する。

## タスク

### Red（テスト作成）
- [ ] `spec/services/post_cache_service_spec.rb` 作成
  - `cache_post(post)` で `LPUSH tl:global`
  - `LTRIM tl:global 0 49` で50件制限
  - `get_cached_ids(limit)` でID取得

### Green（実装）
- [ ] `app/services/post_cache_service.rb` 作成
- [ ] `PostsController#create` でキャッシュ更新
- [ ] `PostsController#index` でキャッシュ読み込み

### Refactor（改善）
- [ ] キャッシュミス時のDB補完ロジック
- [ ] Redis接続エラーハンドリング

## 依存
- Phase 2.2完了後に着手

## 関連
- Phase 2: Rails APIバックエンド実装
- 仕様: `docs/specs.md` のRedisキャッシュ戦略
- GitHub Issue: #9